### PR TITLE
إضافة ملف common-debug واستخدامه

### DIFF
--- a/admin-page.php
+++ b/admin-page.php
@@ -1,4 +1,6 @@
 <?php
+// تضمين دوال التصحيح المشتركة
+require_once plugin_dir_path(__FILE__) . 'includes/common-debug.php';
 /**
  * عرض صفحة الـ AI Agent (الواجهة الأساسية للدردشة).
  */

--- a/ajax-handler.php
+++ b/ajax-handler.php
@@ -3,16 +3,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // لا وصول مباشر
 }
 
-/**
- * دالة مساعدة لتسجيل رسائل AJAX في debug.log.
- *
- * @param string $action اسم هوك AJAX الحالي مع الحالة (بدء/انتهاء).
- */
-function wpai_debug_log_ajax( $action ) {
-    if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-        error_log( "[ajax-handler.php::$action] استدعاء AJAX: $action" );
-    }
-}
+// تضمين دوال التصحيح المشتركة
+require_once plugin_dir_path( __FILE__ ) . 'includes/common-debug.php';
+
 
 /**
  * حفظ جلسة جديدة في قاعدة البيانات.

--- a/includes/common-debug.php
+++ b/includes/common-debug.php
@@ -1,0 +1,19 @@
+<?php
+// common-debug.php - دوال تصحيح موحدة للإضافة
+
+if (!function_exists('wpai_debug_log')) {
+    function wpai_debug_log($message, $context = '') {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            $prefix = $context ? "[$context] " : '';
+            error_log($prefix . $message);
+        }
+    }
+}
+
+if (!function_exists('wpai_debug_log_ajax')) {
+    function wpai_debug_log_ajax($action) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log("[AJAX::$action] تنفيذ إجراء AJAX: $action");
+        }
+    }
+}

--- a/includes/rest-command-handler.php
+++ b/includes/rest-command-handler.php
@@ -3,6 +3,9 @@
 
 if (!defined('ABSPATH')) exit;
 
+// تضمين دوال التصحيح المشتركة
+require_once plugin_dir_path(__DIR__) . '/includes/common-debug.php';
+
 add_action('rest_api_init', function () {
     register_rest_route('wpai/v1', '/execute', [
         'methods' => 'POST',

--- a/wp-ai-agent.php
+++ b/wp-ai-agent.php
@@ -10,22 +10,8 @@ if (!defined('ABSPATH')) {
     exit; // لا وصول مباشر
 }
 
-/**
- * دالة مساعدة لتسجيل رسائل التصحيح.
- * تسجّل الرسائل في error_log إذا كان WP_DEBUG مفعلًا.
- *
- * @param string $message رسالة التتبع أو الخطأ.
- * @param string $context (اختياري) معلومات إضافية.
- */
-function wpai_debug_log($message, $context = '') {
-    if (defined('WP_DEBUG') && WP_DEBUG) {
-        $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
-        $file = isset($caller['file']) ? basename($caller['file']) : '';
-        $func = isset($caller['function']) ? $caller['function'] : '';
-        $entry = sprintf("[%s::%s] %s %s", $file, $func, $message, $context);
-        error_log($entry);
-    }
-}
+// تضمين دوال التصحيح المشتركة
+require_once plugin_dir_path(__FILE__) . 'includes/common-debug.php';
 
 /**
  * عند تفعيل الإضافة: إنشاء جدول الجلسات في قاعدة البيانات إذا لم يكن موجودًا.


### PR DESCRIPTION
## ملخص
- إضافة ملف `includes/common-debug.php` لتعريف الدوال `wpai_debug_log` و`wpai_debug_log_ajax`
- ربط الملف في `wp-ai-agent.php` و`ajax-handler.php` و`admin-page.php` و`includes/rest-command-handler.php`
- إزالة التعريفات المكررة من الملفات السابقة

## الاختبارات
- `php -l includes/common-debug.php`
- `php -l wp-ai-agent.php`
- `php -l ajax-handler.php`
- `php -l admin-page.php`
- `php -l includes/rest-command-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_6853340958c0832fa5ec2ae7fedb34db