### PR TITLE
Add REST key fetch and header support

### DIFF
--- a/1.js
+++ b/1.js
@@ -92,6 +92,8 @@ jQuery(function($) {
     }
 
     let apiKey = '';
+    // مفتاح REST العام للأوامر
+    let globalRestKey = '';
     let aiProvider = 'gpt';
     let instructionsSent = false;
     const PROMPT_SENT_KEY = 'wpai_prompt_sent';
@@ -381,6 +383,17 @@ jQuery(function($) {
             logManager.log("تم تحميل المفتاح الأصلي");
         }
 
+        // جلب المفتاح العام للأوامر REST من الخادم
+        const restKeyResp = await $.post(wpAiAgent.ajaxUrl, {
+            action: 'wpai_get_global_api_key',
+            security: wpAiAgent.nonce
+        });
+
+        if (restKeyResp.success && restKeyResp.data.key) {
+            globalRestKey = restKeyResp.data.key;
+            logManager.log("🔐 تم تحميل المفتاح العام");
+        }
+
         await trySendBasePrompt();
         try {
             const stored = memoryManager.getContext();
@@ -394,4 +407,5 @@ jQuery(function($) {
 
     window.memoryManager = memoryManager;
     window.sendToAI = sendToAI;
+    window.globalRestKey = globalRestKey;
 });

--- a/ai-code-executor.js
+++ b/ai-code-executor.js
@@ -79,22 +79,33 @@
       }
     },
 
-    handleJSON(json) {
+    async handleJSON(json) {
       wpAiUI.appendLog(`⏳ التحقق من بنية JSON...`);
       if (!this.isValidJSON(json)) {
         throw new Error('بنية JSON غير صالحة');
       }
       wpAiUI.appendLog(`🚀 إرسال JSON للسيرفر...`);
-      return $.post(ajaxUrl, {
-        action: 'wpai_execute_code',
-        payload: json,
-        type: 'json'
+
+      const headers = { 'Content-Type': 'application/json' };
+      // إضافة مفتاح REST العام للترويسات عند توفره
+      if (window.globalRestKey) {
+        headers['x-api-key'] = window.globalRestKey;
+      }
+
+      const res = await fetch(wpAiAgent.restEndpoint, {
+        method: 'POST',
+        headers,
+        body: json
       });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || res.statusText);
+      return data;
     },
 
     handlePHP(code) {
       wpAiUI.appendLog(`🚀 إرسال كود PHP للسيرفر...`);
-      return $.post(ajaxUrl, {
+      return $.post(wpAiAgent.ajaxUrl, {
         action: 'wpai_execute_code',
         payload: code,
         type: 'php',

--- a/ajax-handler.php
+++ b/ajax-handler.php
@@ -198,6 +198,28 @@ add_action( 'wp_ajax_wpai_save_global_api_key', function() {
 } );
 
 /**
+ * جلب المفتاح العالمي للأوامر REST.
+ */
+add_action( 'wp_ajax_wpai_get_global_api_key', function() {
+    wpai_debug_log_ajax( 'wpai_get_global_api_key - بدء' );
+    check_ajax_referer( 'wp_ai_agent_nonce', 'security' );
+
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_send_json_error( [ 'message' => 'صلاحيات غير كافية.' ] );
+        return;
+    }
+
+    $key = get_option( 'wpai_global_api_key' );
+    if ( empty( $key ) ) {
+        wp_send_json_error( [ 'message' => 'لا يوجد مفتاح.' ] );
+        wpai_debug_log_ajax( 'wpai_get_global_api_key - لا يوجد مفتاح' );
+    } else {
+        wp_send_json_success( [ 'key' => $key ] );
+        wpai_debug_log_ajax( 'wpai_get_global_api_key - انتهى بنجاح' );
+    }
+} );
+
+/**
  * جلب مفتاح API الأصلي للمستخدم الحالي.
  */
 add_action( 'wp_ajax_wpai_get_api_key', function() {

--- a/wp-ai-agent.php
+++ b/wp-ai-agent.php
@@ -37,6 +37,14 @@ function wpai_activate_plugin() {
 
 
     dbDelta($sql);
+
+    // توليد مفتاح REST عام إذا لم يكن موجودًا بالفعل
+    if (!get_option('wpai_global_api_key')) {
+        $generated_key = bin2hex(random_bytes(16));
+        add_option('wpai_global_api_key', $generated_key);
+        wpai_debug_log('تم توليد مفتاح REST عام بشكل تلقائي');
+    }
+
     wpai_debug_log("تم تشغيل wpai_activate_plugin: تم إنشاء جدول الجلسات إن لم يكن موجودًا");
 }
 register_activation_hook(__FILE__, 'wpai_activate_plugin');
@@ -194,6 +202,7 @@ function wpai_enqueue_admin_assets($hook) {
             'basePrompt' => $base_prompt,
             'userId'     => get_current_user_id(),
             'pluginUrl'  => plugin_dir_url(__FILE__),
+            'restEndpoint' => rest_url('wpai/v1/execute'),
         ]
     );
 }


### PR DESCRIPTION
## Summary
- generate a REST key on activation and expose REST endpoint to JS
- provide AJAX action to fetch the global REST key
- fetch REST key in `1.js` and store in `globalRestKey`
- send JSON commands with `x-api-key` header in `ai-code-executor.js`

## Testing
- `php -l wp-ai-agent.php`
- `php -l ajax-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_685355ba77e4832f8b310829c5ba496a