### PR TITLE
إضافة سجل للأوامر وتحسين التحقق من REST

### DIFF
--- a/admin-page.php
+++ b/admin-page.php
@@ -46,10 +46,45 @@ function wpai_render_agent_page() {
                     </div>
                     <div class="wpai-system-logs"></div>
                 </div>
+
+                <div id="command-logs" class="wpai-log-container">
+                    <h2>سجلات الأوامر</h2>
+                    <div class="wpai-log-controls">
+                        <button id="refresh-command-logs" class="button">تحديث السجلات</button>
+                    </div>
+                    <div class="wpai-command-logs"></div>
+                </div>
             </div>
             <div id="container3" style="display: none;"></div>
         </div>
     </div>
+    <script>
+    jQuery(function($) {
+        function loadCommandLogs() {
+            $.post(ajaxurl, {
+                action: 'wpai_get_command_logs',
+                security: wpAiAgent.nonce
+            }, function(response) {
+                if (response.success) {
+                    $('.wpai-command-logs').html(
+                        response.data.logs.map(log =>
+                            `<div class="log-entry">
+                                <strong>${log.timestamp}</strong> - 
+                                ${log.command}: ${log.status}
+                                <button class="view-log-details button" data-log='${JSON.stringify(log)}'>
+                                    التفاصيل
+                                </button>
+                            </div>`
+                        ).join('')
+                    );
+                }
+            });
+        }
+
+        $('#refresh-command-logs').click(loadCommandLogs);
+        loadCommandLogs();
+    });
+    </script>
     <?php
     wpai_debug_log("انتهى عرض صفحة WP AI Agent");
 }

--- a/ajax-handler.php
+++ b/ajax-handler.php
@@ -270,6 +270,13 @@ add_action( 'wp_ajax_wpai_clear_logs', function() {
     wpai_debug_log_ajax( 'wpai_clear_logs - انتهى بنجاح' );
 } );
 
+add_action('wp_ajax_wpai_get_command_logs', function() {
+    check_ajax_referer('wp_ai_agent_nonce', 'security');
+
+    $logs = get_option('wpai_command_logs', []);
+    wp_send_json_success(['logs' => $logs]);
+});
+
 /**
  * حفظ الذاكرة (memory) في user_meta.
  */


### PR DESCRIPTION
## Summary
- add detailed API key verification logs
- check user permissions before executing commands
- wrap command execution with error handling and verbose logs
- log command results with status info
- improve post creation content handling
- expose command logs in admin page and via AJAX

## Testing
- `php -l includes/rest-command-handler.php`
- `php -l admin-page.php`
- `php -l ajax-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_68535bef6b2c832fabd0fb0ed86c3df4