### PR TITLE
Allow REST API auth bypass if no key set

### DIFF
--- a/includes/rest-command-handler.php
+++ b/includes/rest-command-handler.php
@@ -23,8 +23,14 @@ add_action('rest_api_init', function () {
 
 
 function wpai_verify_api_key($request) {
-    $api_key = $request->get_header('X-WPAI-API-KEY');
+    $api_key   = $request->get_header('X-WPAI-API-KEY');
     $stored_key = get_option('wpai_global_api_key');
+
+    // إذا لم يتم تعيين مفتاح عام، نتخطى التحقق للسماح بالطلبات
+    if (empty($stored_key)) {
+        return true;
+    }
+
     return $api_key && hash_equals($stored_key, $api_key);
 }
 

--- a/wp-ai-agent.php
+++ b/wp-ai-agent.php
@@ -255,6 +255,7 @@ function wpai_render_settings_page() {
                     <td>
                         <input type="password" id="api-key-input" name="api_key" value="<?php echo esc_attr($current_key ? '********' : ''); ?>" placeholder="أدخل مفتاح API هنا" style="width:300px;">
                         <p class="description">إذا كنت تريد تغيير المفتاح، أدخله هنا ثم اضغط “حفظ المفتاح”.</p>
+                        <p class="description">ترك هذا الحقل فارغًا يعطّل التحقق من الطلبات عبر REST.</p>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
## Summary
- let `wpai_verify_api_key()` succeed when no global key is configured
- clarify in settings that an empty API key disables verification

## Testing
- `php -l includes/rest-command-handler.php`
- `php -l wp-ai-agent.php`

------
https://chatgpt.com/codex/tasks/task_e_685410e859c4832f8ff0b1b2d4186370